### PR TITLE
Add PyPI packaging and publish workflows

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,0 +1,55 @@
+name: Publish packages to PyPI
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build distributions
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install build tooling
+        run: python -m pip install --upgrade pip build twine setuptools wheel
+
+      - name: Build all packages
+        run: bash scripts/build-all-packages.sh
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          if-no-files-found: error
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/qcsc-prefect
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/testpypi-publish.yml
+++ b/.github/workflows/testpypi-publish.yml
@@ -2,6 +2,11 @@ name: Publish packages to TestPyPI
 
 on:
   workflow_dispatch:
+    inputs:
+      publish:
+        description: "Publish built distributions to TestPyPI"
+        required: true
+        default: "false"
 
 permissions:
   contents: read
@@ -35,6 +40,7 @@ jobs:
   publish:
     name: Publish to TestPyPI
     needs: build
+    if: ${{ inputs.publish == 'true' }}
     runs-on: ubuntu-latest
     environment:
       name: testpypi

--- a/.github/workflows/testpypi-publish.yml
+++ b/.github/workflows/testpypi-publish.yml
@@ -1,0 +1,55 @@
+name: Publish packages to TestPyPI
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build distributions
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install build tooling
+        run: python -m pip install --upgrade pip build twine setuptools wheel
+
+      - name: Build all packages
+        run: bash scripts/build-all-packages.sh
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          if-no-files-found: error
+
+  publish:
+    name: Publish to TestPyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/qcsc-prefect
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish distributions to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/

--- a/README.md
+++ b/README.md
@@ -176,6 +176,20 @@ Do not add PyPI API tokens or password secrets to this repository.
 7. Confirm PyPI or TestPyPI Trusted Publisher settings match the workflow and environment.
 8. Push a tag like `v0.1.0` to trigger the PyPI publish workflow.
 
+### Release Validation Note
+
+For the `0.1.0` packaging validation:
+
+- GitHub Actions build-only dry run completed.
+- All packages built into wheel and sdist distributions.
+- `twine check` passed.
+- Local install from `dist/` passed with
+  `pip install --find-links qcsc-prefect-dist "qcsc-prefect[all]==0.1.0"`.
+- The Qiskit integration import path is `qcsc_prefect.integrations.qiskit`.
+- The DICE executable is not installed by `pip`; it must be built separately on the target HPC system.
+- TestPyPI Trusted Publisher registration for multiple packages is currently blocked by a suspected
+  PyPI/TestPyPI pending publisher issue, so no actual upload was performed.
+
 ## Contribution Guidelines
 
 1. Install pre-commit hooks:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repository provides a modular workspace for portable HPC workflow orchestration with Prefect.
 It is designed so the same workflow code can run across multiple HPC systems by switching profile blocks.
 
-The workspace is organized into four core packages:
+The workspace is organized into core packages, optional integrations, and a PyPI meta-package:
 
 ```
 qcsc-prefect/
@@ -14,16 +14,21 @@ qcsc-prefect/
 │   ├── prefect_bitcount_demo
 │   └── miyabi_prefect_hello_demo
 ├── packages
+│   ├── qcsc-prefect
 │   ├── qcsc-prefect-core
 │   ├── qcsc-prefect-blocks
 │   ├── qcsc-prefect-adapters
-│   └── qcsc-prefect-executor
+│   ├── qcsc-prefect-executor
+│   ├── qcsc-prefect-qiskit
+│   └── qcsc-prefect-dice
 ├── pyproject.toml
 └── .pre-commit-config.yaml
 ```
 
 ## Repository Structure
 
+- `packages/qcsc-prefect/`
+  Meta-package for installing the core QCSC Prefect packages from PyPI.
 - `packages/qcsc-prefect-core/`
   Common execution model definitions (for example `ExecutionProfile`) shared by all targets.
 - `packages/qcsc-prefect-blocks/`
@@ -33,10 +38,100 @@ qcsc-prefect/
 - `packages/qcsc-prefect-executor/`
   High-level execution entrypoints that resolve blocks, derive scheduler routing,
   and dispatch to target runtimes.
+- `packages/qcsc-prefect-qiskit/`
+  Optional native Qiskit Runtime integration utilities.
+- `packages/qcsc-prefect-dice/`
+  Optional DICE SHCI solver integration.
 - `examples/`
   End-to-end runnable examples for Miyabi and Fugaku.
 - `docs/`
   Concept and architecture documents for the block-based execution model.
+
+## Installation
+
+Install the core QCSC Prefect packages from PyPI with:
+
+```bash
+pip install qcsc-prefect
+```
+
+Install the core packages plus the native Qiskit integration with:
+
+```bash
+pip install "qcsc-prefect[qiskit]"
+```
+
+Install the core packages plus the Python-side DICE integration with:
+
+```bash
+pip install "qcsc-prefect[dice]"
+```
+
+Install all optional integrations with:
+
+```bash
+pip install "qcsc-prefect[all]"
+```
+
+The DICE integration can also be installed directly:
+
+```bash
+pip install qcsc-prefect-dice
+```
+
+For source development, install the workspace with uv from the repository root:
+
+```bash
+git clone https://github.com/qiskit-community/qcsc-prefect.git
+cd qcsc-prefect
+uv sync --all-packages
+uv run pytest
+```
+
+The root `pyproject.toml` is a workspace coordinator and is not the package published to PyPI.
+Each package under `packages/` remains independently buildable.
+
+## DICE Integration
+
+`qcsc-prefect-dice` is a Python-side integration package. Installing it provides Prefect
+tasks/blocks, scheduler templates, DICE input/output handling, and documentation. It does
+not build, download, vendor, or install the external DICE/SBD executable.
+
+The DICE/SBD executable must already be compiled on the target HPC system. Build instructions
+are site-specific because compilers, MPI stacks, BLAS/LAPACK libraries, GPU support, filesystem
+layout, and scheduler environments differ across HPC systems.
+
+Configure the DICE executable through the command configuration used by the target HPC profile.
+In the current block model, the `CommandBlock` names the executable key and the `HPCProfileBlock`
+maps that key to the executable path visible on the target HPC system:
+
+```python
+from qcsc_prefect_blocks.common.blocks import CommandBlock, HPCProfileBlock
+
+CommandBlock(
+    command_name="dice",
+    executable_key="dice_solver",
+    description="DICE SHCI solver executable",
+    default_args=[],
+).save("cmd-dice-solver", overwrite=True)
+
+HPCProfileBlock(
+    hpc_target="miyabi",
+    queue_cpu="regular-c",
+    queue_gpu="regular-g",
+    project_cpu="gz00",
+    project_gpu="gz00",
+    executable_map={
+        "dice_solver": "/work/gz00/<user>/dice/bin/Dice",
+    },
+).save("hpc-miyabi-dice", overwrite=True)
+```
+
+Generated Miyabi, Fugaku, and Slurm job scripts include a preflight check that runs on the
+HPC node before launching the job. The script fails early with a clear message if the configured
+executable path is empty, missing, not executable, or not found on `PATH`.
+
+See [DICE Integration](./docs/howto/howto_use_dice_prefect.md) for a longer setup example.
 
 ## Documentation
 
@@ -63,6 +158,23 @@ Code quality checks are configured with pre-commit (`.pre-commit-config.yaml`):
 
 Each sub-package under `packages/` maintains its own version in its own `pyproject.toml`.
 The root project is a workspace coordinator (`qcsc-prefect-workspace`) and is not intended for distribution.
+For a coordinated PyPI release, keep the `qcsc-prefect-*` package versions and exact internal
+dependency pins aligned, for example `0.1.0`.
+
+## Release Checklist
+
+Maintainers can publish through GitHub Actions with PyPI Trusted Publishing.
+Do not add PyPI API tokens or password secrets to this repository.
+
+1. Update versions in every publishable package under `packages/`.
+2. Update exact internal dependency pins between `qcsc-prefect-*` packages.
+3. Run `python -m pip install --upgrade build twine`.
+4. Run `bash scripts/build-all-packages.sh`.
+5. Run `python -m twine check dist/*`.
+6. Test local wheel installs from `dist/`, including `qcsc-prefect`,
+   `qcsc-prefect[qiskit]`, `qcsc-prefect[dice]`, and `qcsc-prefect[all]`.
+7. Confirm PyPI or TestPyPI Trusted Publisher settings match the workflow and environment.
+8. Push a tag like `v0.1.0` to trigger the PyPI publish workflow.
 
 ## Contribution Guidelines
 

--- a/docs/howto/howto_use_dice_prefect.md
+++ b/docs/howto/howto_use_dice_prefect.md
@@ -1,0 +1,94 @@
+# DICE Integration
+
+`qcsc-prefect-dice` provides the Python-side integration for DICE/SBD workflows:
+
+- Prefect block and task helpers
+- Scheduler script templates
+- DICE input file rendering
+- DICE output parsing
+- Documentation and block creation helpers
+
+It does not build, download, vendor, or install the external DICE/SBD executable. The executable
+must already be compiled separately for the target HPC environment.
+
+## Installation
+
+Install through the meta-package extra:
+
+```bash
+pip install "qcsc-prefect[dice]"
+```
+
+Install all optional integrations with:
+
+```bash
+pip install "qcsc-prefect[all]"
+```
+
+Direct installation also works:
+
+```bash
+pip install qcsc-prefect-dice
+```
+
+These commands install only Python dependencies and Python integration code. They do not compile
+or install the DICE/SBD solver binary.
+
+## External Solver Binary
+
+Build the DICE/SBD executable on each target HPC system according to local site requirements.
+Build instructions are site-specific because compilers, MPI implementations, BLAS/LAPACK
+libraries, GPU support, filesystem layout, and scheduler environments differ across systems.
+
+Use an executable path that is valid from the submitted HPC job. The local machine that creates
+Prefect blocks does not need to be able to access that path.
+
+## Command Block Configuration
+
+The shared execution model resolves executable paths through the command key configured in
+Prefect blocks. The `CommandBlock` declares the logical executable key, and the `HPCProfileBlock`
+maps that key to the target-system executable path.
+
+```python
+from qcsc_prefect_blocks.common.blocks import CommandBlock, ExecutionProfileBlock, HPCProfileBlock
+
+CommandBlock(
+    command_name="dice",
+    executable_key="dice_solver",
+    description="DICE SHCI solver executable",
+    default_args=[],
+).save("cmd-dice-solver", overwrite=True)
+
+ExecutionProfileBlock(
+    profile_name="dice-mpi",
+    command_name="dice",
+    resource_class="cpu",
+    num_nodes=1,
+    mpiprocs=4,
+    walltime="01:00:00",
+    launcher="mpiexec.hydra",
+).save("exec-dice-mpi", overwrite=True)
+
+HPCProfileBlock(
+    hpc_target="miyabi",
+    queue_cpu="regular-c",
+    queue_gpu="regular-g",
+    project_cpu="gz00",
+    project_gpu="gz00",
+    executable_map={
+        "dice_solver": "/work/gz00/<user>/dice/bin/Dice",
+    },
+).save("hpc-miyabi-dice", overwrite=True)
+```
+
+The helper `qcsc_prefect_dice.create_dice_blocks()` creates the same block set and accepts the
+target-system path through its `dice_executable` argument.
+
+## Runtime Validation
+
+Generated Miyabi, Fugaku, and Slurm scripts validate the configured executable at job runtime.
+The preflight runs on the HPC node before the solver launch and fails early if the executable is
+empty, missing, not executable, or not found on `PATH`.
+
+The generated check is intentionally script-side rather than local Python-side, because the
+machine creating Prefect blocks may not have access to the target HPC filesystem.

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,6 +20,7 @@ qcsc-prefect/
 │   ├── qcsc-prefect-blocks/
 │   ├── qcsc-prefect-adapters/
 │   ├── qcsc-prefect-executor/
+│   ├── qcsc-prefect-qiskit/
 │   └── qcsc-prefect-dice/
 ├── algorithms/
 ├── examples/

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,6 +52,7 @@ nav:
       - Native Qiskit on Prefect: howto/howto_use_native_qiskit_prefect.md
       - Prefect Qiskit Setup: howto/howto_setup_prefect_qiskit.md
       - Prefect Qiskit Setup (Fugaku): howto/howto_setup_prefect_qiskit_fugaku.md
+      - DICE Integration: howto/howto_use_dice_prefect.md
       - Connect to Prefect on MDX: howto/howto_connect_to_prefect_on_mdx.md
       - Python Environment: howto/howto_setup_python_env.md
       - Python Environment (Fugaku): howto/howto_setup_python_env_fugaku.md

--- a/packages/qcsc-prefect-adapters/README.md
+++ b/packages/qcsc-prefect-adapters/README.md
@@ -1,0 +1,3 @@
+# QCSC Prefect Adapters
+
+Scheduler adapters and Jinja2 script templates for QCSC Prefect workflows.

--- a/packages/qcsc-prefect-adapters/pyproject.toml
+++ b/packages/qcsc-prefect-adapters/pyproject.toml
@@ -1,21 +1,39 @@
 [build-system]
-requires = ["setuptools>=68", "wheel"]
+requires = ["setuptools>=77.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "qcsc-prefect-adapters"
 version = "0.1.0"
 description = "HPC adapters (Miyabi, Fugaku, Slurm) for QCSC Prefect workflows"
+readme = "README.md"
 requires-python = ">=3.10"
-dependencies = [
-    "qcsc-prefect-core",
+license = "Apache-2.0"
+authors = [
+    { name = "QCSC Prefect Contributors" },
 ]
+maintainers = [
+    { name = "QCSC Prefect Maintainers" },
+]
+dependencies = [
+    "Jinja2>=3.1",
+    "qcsc-prefect-core==0.1.0",
+]
+
+[project.urls]
+Homepage = "https://github.com/qiskit-community/qcsc-prefect"
+Repository = "https://github.com/qiskit-community/qcsc-prefect"
+Documentation = "https://qiskit-community.github.io/qcsc-prefect/"
+Issues = "https://github.com/qiskit-community/qcsc-prefect/issues"
 
 [tool.setuptools.packages.find]
 where = ["src"]
+namespaces = true
 
 [tool.setuptools]
 include-package-data = true
 
 [tool.setuptools.package-data]
-"qcsc_prefect_adapters" = ["**/*.j2"]
+"qcsc_prefect_adapters.miyabi" = ["templates/*.j2"]
+"qcsc_prefect_adapters.fugaku" = ["templates/*.j2"]
+"qcsc_prefect_adapters.slurm" = ["templates/*.j2"]

--- a/packages/qcsc-prefect-adapters/src/qcsc_prefect_adapters/fugaku/templates/batch.pjm.j2
+++ b/packages/qcsc-prefect-adapters/src/qcsc_prefect_adapters/fugaku/templates/batch.pjm.j2
@@ -44,19 +44,38 @@ spack load {{ module }}
 export {{ k }}="{{ v }}"
 {% endfor %}
 {% endif %}
+QCSC_PREFECT_EXECUTABLE="{{ executable }}"
+if [ -z "${QCSC_PREFECT_EXECUTABLE}" ]; then
+  echo "QCSC Prefect preflight failed: executable path is empty." >&2
+  exit 127
+fi
+case "${QCSC_PREFECT_EXECUTABLE}" in
+  */*)
+    if [ ! -x "${QCSC_PREFECT_EXECUTABLE}" ]; then
+      echo "QCSC Prefect preflight failed: executable '${QCSC_PREFECT_EXECUTABLE}' does not exist or is not executable on this HPC node." >&2
+      exit 127
+    fi
+    ;;
+  *)
+    if ! command -v "${QCSC_PREFECT_EXECUTABLE}" >/dev/null 2>&1; then
+      echo "QCSC Prefect preflight failed: executable '${QCSC_PREFECT_EXECUTABLE}' was not found on PATH on this HPC node." >&2
+      exit 127
+    fi
+    ;;
+esac
 {% if launcher == "single" %}
-{% set base_cmd = executable %}
+{% set base_cmd = '"${QCSC_PREFECT_EXECUTABLE}"' %}
 {% elif launcher == "mpiexec" %}
 {% if mpi_options %}
-{% set base_cmd = "mpiexec " ~ (' '.join(mpi_options)) ~ " " ~ executable %}
+{% set base_cmd = "mpiexec " ~ (' '.join(mpi_options)) ~ ' "${QCSC_PREFECT_EXECUTABLE}"' %}
 {% else %}
-{% set base_cmd = "mpiexec " ~ executable %}
+{% set base_cmd = 'mpiexec "${QCSC_PREFECT_EXECUTABLE}"' %}
 {% endif %}
 {% else %}
 {% if mpi_options %}
-{% set base_cmd = launcher ~ " " ~ (' '.join(mpi_options)) ~ " " ~ executable %}
+{% set base_cmd = launcher ~ " " ~ (' '.join(mpi_options)) ~ ' "${QCSC_PREFECT_EXECUTABLE}"' %}
 {% else %}
-{% set base_cmd = launcher ~ " " ~ executable %}
+{% set base_cmd = launcher ~ ' "${QCSC_PREFECT_EXECUTABLE}"' %}
 {% endif %}
 {% endif %}
 {% if arguments %}

--- a/packages/qcsc-prefect-adapters/src/qcsc_prefect_adapters/miyabi/templates/batch.pbs.j2
+++ b/packages/qcsc-prefect-adapters/src/qcsc_prefect_adapters/miyabi/templates/batch.pbs.j2
@@ -35,10 +35,30 @@ export {{ k }}="{{ v }}"
 
 cd {{ work_dir }}
 
+QCSC_PREFECT_EXECUTABLE="{{ executable }}"
+if [ -z "${QCSC_PREFECT_EXECUTABLE}" ]; then
+  echo "QCSC Prefect preflight failed: executable path is empty." >&2
+  exit 127
+fi
+case "${QCSC_PREFECT_EXECUTABLE}" in
+  */*)
+    if [ ! -x "${QCSC_PREFECT_EXECUTABLE}" ]; then
+      echo "QCSC Prefect preflight failed: executable '${QCSC_PREFECT_EXECUTABLE}' does not exist or is not executable on this HPC node." >&2
+      exit 127
+    fi
+    ;;
+  *)
+    if ! command -v "${QCSC_PREFECT_EXECUTABLE}" >/dev/null 2>&1; then
+      echo "QCSC Prefect preflight failed: executable '${QCSC_PREFECT_EXECUTABLE}' was not found on PATH on this HPC node." >&2
+      exit 127
+    fi
+    ;;
+esac
+
 {% if launcher != "single" -%}
-{{ launcher }}{% if mpi_options is defined %} {{ mpi_options | join(' ') }}{% endif %} {{ executable }}
+{{ launcher }}{% if mpi_options is defined %} {{ mpi_options | join(' ') }}{% endif %} "${QCSC_PREFECT_EXECUTABLE}"
 {%- else -%}
-{{ executable }}
+"${QCSC_PREFECT_EXECUTABLE}"
 {%- endif %}
 {%- if arguments is defined -%}
 {{ ' ' ~ arguments | join(' ') }}

--- a/packages/qcsc-prefect-adapters/src/qcsc_prefect_adapters/slurm/templates/batch.slurm.j2
+++ b/packages/qcsc-prefect-adapters/src/qcsc_prefect_adapters/slurm/templates/batch.slurm.j2
@@ -39,10 +39,30 @@ export {{ k }}="{{ v }}"
 
 cd {{ work_dir }}
 
+QCSC_PREFECT_EXECUTABLE="{{ executable }}"
+if [ -z "${QCSC_PREFECT_EXECUTABLE}" ]; then
+  echo "QCSC Prefect preflight failed: executable path is empty." >&2
+  exit 127
+fi
+case "${QCSC_PREFECT_EXECUTABLE}" in
+  */*)
+    if [ ! -x "${QCSC_PREFECT_EXECUTABLE}" ]; then
+      echo "QCSC Prefect preflight failed: executable '${QCSC_PREFECT_EXECUTABLE}' does not exist or is not executable on this HPC node." >&2
+      exit 127
+    fi
+    ;;
+  *)
+    if ! command -v "${QCSC_PREFECT_EXECUTABLE}" >/dev/null 2>&1; then
+      echo "QCSC Prefect preflight failed: executable '${QCSC_PREFECT_EXECUTABLE}' was not found on PATH on this HPC node." >&2
+      exit 127
+    fi
+    ;;
+esac
+
 {% if launcher != "single" -%}
-{{ launcher }}{% if mpi_options is defined %} {{ mpi_options | join(' ') }}{% endif %} {{ executable }}
+{{ launcher }}{% if mpi_options is defined %} {{ mpi_options | join(' ') }}{% endif %} "${QCSC_PREFECT_EXECUTABLE}"
 {%- else -%}
-{{ executable }}
+"${QCSC_PREFECT_EXECUTABLE}"
 {%- endif %}
 {%- if arguments is defined -%}
 {{ ' ' ~ arguments | join(' ') }}

--- a/packages/qcsc-prefect-adapters/tests/test_fugaku_builder.py
+++ b/packages/qcsc-prefect-adapters/tests/test_fugaku_builder.py
@@ -46,4 +46,6 @@ def test_render_fugaku_script_with_modules_env_and_extra_resources(tmp_path: Pat
     assert 'export OMP_NUM_THREADS="48"' in text
     assert 'export UTOFU_SWAP_PROTECT="1"' in text
     assert 'export LD_LIBRARY_PATH="/lib64:$LD_LIBRARY_PATH"' in text
-    assert "mpirun -n 4 /path/to/gb-demo --foo bar" in text
+    assert 'QCSC_PREFECT_EXECUTABLE="/path/to/gb-demo"' in text
+    assert "QCSC Prefect preflight failed: executable '${QCSC_PREFECT_EXECUTABLE}'" in text
+    assert 'mpirun -n 4 "${QCSC_PREFECT_EXECUTABLE}" --foo bar' in text

--- a/packages/qcsc-prefect-adapters/tests/test_miyabi_builder.py
+++ b/packages/qcsc-prefect-adapters/tests/test_miyabi_builder.py
@@ -32,6 +32,9 @@ def test_render_miyabi_script(tmp_path: Path):
     assert "module load intelmpi" in text
     assert "unset OMPI_MCA_mca_base_env_list" in text
     assert 'export OMP_NUM_THREADS="1"' in text
+    assert 'QCSC_PREFECT_EXECUTABLE="/path/to/hello"' in text
+    assert "QCSC Prefect preflight failed: executable '${QCSC_PREFECT_EXECUTABLE}'" in text
     assert req.executable in text
     assert text.index("unset OMPI_MCA_mca_base_env_list") < text.index('export OMP_NUM_THREADS="1"')
-    assert text.index('export OMP_NUM_THREADS="1"') < text.index("mpirun")
+    assert text.index('export OMP_NUM_THREADS="1"') < text.index("QCSC_PREFECT_EXECUTABLE")
+    assert 'mpirun "${QCSC_PREFECT_EXECUTABLE}" --foo bar' in text

--- a/packages/qcsc-prefect-adapters/tests/test_slurm_builder.py
+++ b/packages/qcsc-prefect-adapters/tests/test_slurm_builder.py
@@ -39,4 +39,6 @@ def test_render_slurm_script(tmp_path: Path):
     assert "module load gcc" in text
     assert "echo before-run" in text
     assert 'export OMP_NUM_THREADS="8"' in text
-    assert "srun --cpu-bind=cores /path/to/hello --foo bar" in text
+    assert 'QCSC_PREFECT_EXECUTABLE="/path/to/hello"' in text
+    assert "QCSC Prefect preflight failed: executable '${QCSC_PREFECT_EXECUTABLE}'" in text
+    assert 'srun --cpu-bind=cores "${QCSC_PREFECT_EXECUTABLE}" --foo bar' in text

--- a/packages/qcsc-prefect-blocks/README.md
+++ b/packages/qcsc-prefect-blocks/README.md
@@ -1,0 +1,3 @@
+# QCSC Prefect Blocks
+
+Prefect block definitions for QCSC HPC workflow execution profiles.

--- a/packages/qcsc-prefect-blocks/pyproject.toml
+++ b/packages/qcsc-prefect-blocks/pyproject.toml
@@ -1,15 +1,30 @@
 [build-system]
-requires = ["setuptools>=68", "wheel"]
+requires = ["setuptools>=77.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "qcsc-prefect-blocks"
 version = "0.1.0"
 description = "Prefect block definitions for HPC + Miyabi execution"
+readme = "README.md"
 requires-python = ">=3.10"
+license = "Apache-2.0"
+authors = [
+    { name = "QCSC Prefect Contributors" },
+]
+maintainers = [
+    { name = "QCSC Prefect Maintainers" },
+]
 dependencies = [
     "prefect>=2.19",
+    "pydantic>=2",
 ]
+
+[project.urls]
+Homepage = "https://github.com/qiskit-community/qcsc-prefect"
+Repository = "https://github.com/qiskit-community/qcsc-prefect"
+Documentation = "https://qiskit-community.github.io/qcsc-prefect/"
+Issues = "https://github.com/qiskit-community/qcsc-prefect/issues"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/packages/qcsc-prefect-core/README.md
+++ b/packages/qcsc-prefect-core/README.md
@@ -1,0 +1,3 @@
+# QCSC Prefect Core
+
+Core models and resolution logic for QCSC Prefect workflows.

--- a/packages/qcsc-prefect-dice/README.md
+++ b/packages/qcsc-prefect-dice/README.md
@@ -1,24 +1,29 @@
 # QCSC Prefect DICE
 
-Shared DICE SHCI solver integration for qcsc-prefect workflows.
+Shared Python-side DICE SHCI solver integration for qcsc-prefect workflows.
 
 This package provides:
 
 - `DiceSHCISolverJob` as a Prefect block
 - DICE input/output utilities
 - Block registration and block creation helpers for Miyabi and Fugaku
+- Scheduler script integration and runtime executable preflight checks
 
-It is intended to be reused by multiple algorithms such as SQD and SKQD.
+It is intended to be reused by multiple algorithms such as SQD and SKQD. Installing this
+package does not build, download, vendor, or install the external DICE/SBD executable.
+The executable must be compiled separately for each target HPC environment.
 
-Native build assets live under:
+Build instructions are site-specific because compilers, MPI stacks, BLAS/LAPACK libraries,
+GPU support, filesystem layout, and scheduler environments differ across HPC systems.
+
+Source-tree native build helper assets live under:
 
 ```text
 packages/qcsc-prefect-dice/native
 ```
 
-See [native/README.md](./native/README.md)
-for build instructions and how to point `dice_executable` at the resulting
-binary.
+They are not part of the Python package install. See [native/README.md](./native/README.md)
+for development notes and how to point `dice_executable` at the separately built binary.
 
 ## Usage Example
 
@@ -30,7 +35,7 @@ block_names = create_dice_blocks(
     project="gz00",
     queue="regular-c",
     root_dir="/work/gz00/<user>/dice_jobs",
-    dice_executable="/work/gz00/<user>/qcsc-prefect-dice/native/bin/Dice",
+    dice_executable="/work/gz00/<user>/dice/bin/Dice",
     solver_block_name="sqd-dice-solver",
 )
 
@@ -46,3 +51,7 @@ result = await solver.run(
 
 `SQD` and `SKQD` can use the same shared package and only vary block names or
 their algorithm-specific setup wrappers.
+
+The configured executable path is stored in the HPC profile executable map under the command
+block key `dice_solver`. Generated job scripts validate that path on the HPC node before
+launching DICE and fail early with a clear message if it is missing or not executable.

--- a/packages/qcsc-prefect-dice/native/README.md
+++ b/packages/qcsc-prefect-dice/native/README.md
@@ -3,6 +3,10 @@
 This directory stores the native build scripts and site-specific build settings
 used to build the DICE executable for qcsc-prefect workflows.
 
+These scripts are source-tree helpers only. Installing `qcsc-prefect-dice` with
+pip does not run them, download native dependencies, or install a DICE/SBD
+binary.
+
 The Python integration lives in:
 
 ```text

--- a/packages/qcsc-prefect-dice/pyproject.toml
+++ b/packages/qcsc-prefect-dice/pyproject.toml
@@ -1,26 +1,43 @@
 [build-system]
-requires = ["setuptools>=68", "wheel"]
+requires = ["setuptools>=77.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "qcsc-prefect-dice"
-version = "1.0.0"
+version = "0.1.0"
 description = "DICE SHCI solver integration for qcsc-prefect"
 readme = "README.md"
 requires-python = ">=3.10"
+license = "Apache-2.0"
+authors = [
+    { name = "QCSC Prefect Contributors" },
+]
+maintainers = [
+    { name = "QCSC Prefect Maintainers" },
+]
 dependencies = [
-    "Jinja2",
+    "Jinja2>=3.1",
     "numpy",
     "prefect>=2.19",
+    "pydantic>=2",
     "pyscf",
     "qiskit-addon-sqd==0.11.0",
-    "qcsc-prefect-core",
-    "qcsc-prefect-blocks",
-    "qcsc-prefect-executor",
+    "qcsc-prefect-blocks==0.1.0",
+    "qcsc-prefect-core==0.1.0",
+    "qcsc-prefect-executor==0.1.0",
 ]
+
+[project.urls]
+Homepage = "https://github.com/qiskit-community/qcsc-prefect"
+Repository = "https://github.com/qiskit-community/qcsc-prefect"
+Documentation = "https://qiskit-community.github.io/qcsc-prefect/"
+Issues = "https://github.com/qiskit-community/qcsc-prefect/issues"
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.setuptools]
+include-package-data = true
 
 [tool.setuptools.package-data]
 qcsc_prefect_dice = ["templates/*.j2"]

--- a/packages/qcsc-prefect-dice/src/qcsc_prefect_dice/block_utils.py
+++ b/packages/qcsc-prefect-dice/src/qcsc_prefect_dice/block_utils.py
@@ -80,11 +80,12 @@ def create_dice_blocks(
     resolved_metrics_key = metrics_artifact_key or (
         "miyabi-dice-metrics" if hpc_target == "miyabi" else "fugaku-dice-metrics"
     )
-    resolved_dice_executable = str(Path(dice_executable).expanduser().resolve())
+    resolved_dice_executable = str(dice_executable)
     resolved_environments = dict(environments or {})
     if hpc_target == "fugaku" and "LD_LIBRARY_PATH" not in resolved_environments:
         dice_bin_dir = str(Path(resolved_dice_executable).parent)
-        resolved_environments["LD_LIBRARY_PATH"] = f"{dice_bin_dir}:$LD_LIBRARY_PATH"
+        if dice_bin_dir != ".":
+            resolved_environments["LD_LIBRARY_PATH"] = f"{dice_bin_dir}:$LD_LIBRARY_PATH"
 
     CommandBlock(
         command_name=command_name,

--- a/packages/qcsc-prefect-dice/tests/test_block_utils.py
+++ b/packages/qcsc-prefect-dice/tests/test_block_utils.py
@@ -36,7 +36,7 @@ def test_create_dice_blocks_miyabi(monkeypatch, tmp_path):
         project="gz00",
         queue="regular-c",
         root_dir=str(tmp_path / "jobs"),
-        dice_executable=str(tmp_path / "bin" / "Dice"),
+        dice_executable="$DICE_ROOT/bin/Dice",
     )
 
     assert names == {
@@ -52,6 +52,7 @@ def test_create_dice_blocks_miyabi(monkeypatch, tmp_path):
     assert hpc_block.hpc_target == "miyabi"
     assert hpc_block.queue_cpu == "regular-c"
     assert hpc_block.project_cpu == "gz00"
+    assert hpc_block.executable_map["dice_solver"] == "$DICE_ROOT/bin/Dice"
 
 
 def test_create_dice_blocks_fugaku(monkeypatch, tmp_path):

--- a/packages/qcsc-prefect-executor/README.md
+++ b/packages/qcsc-prefect-executor/README.md
@@ -1,0 +1,3 @@
+# QCSC Prefect Executor
+
+Prefect executor integrations for QCSC HPC scheduler workflows.

--- a/packages/qcsc-prefect-executor/pyproject.toml
+++ b/packages/qcsc-prefect-executor/pyproject.toml
@@ -1,18 +1,32 @@
 [build-system]
-requires = ["setuptools>=68", "wheel"]
+requires = ["setuptools>=77.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "qcsc-prefect-executor"
 version = "0.1.0"
 description = "Prefect executor integrations for HPC schedulers"
+readme = "README.md"
 requires-python = ">=3.10"
-dependencies = [
-    "qcsc-prefect-core",
-    "qcsc-prefect-adapters",
-    "qcsc-prefect-blocks",
-    "prefect>=2.19",
+license = "Apache-2.0"
+authors = [
+    { name = "QCSC Prefect Contributors" },
 ]
+maintainers = [
+    { name = "QCSC Prefect Maintainers" },
+]
+dependencies = [
+    "prefect>=2.19",
+    "qcsc-prefect-adapters==0.1.0",
+    "qcsc-prefect-blocks==0.1.0",
+    "qcsc-prefect-core==0.1.0",
+]
+
+[project.urls]
+Homepage = "https://github.com/qiskit-community/qcsc-prefect"
+Repository = "https://github.com/qiskit-community/qcsc-prefect"
+Documentation = "https://qiskit-community.github.io/qcsc-prefect/"
+Issues = "https://github.com/qiskit-community/qcsc-prefect/issues"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/packages/qcsc-prefect-qiskit/README.md
+++ b/packages/qcsc-prefect-qiskit/README.md
@@ -1,0 +1,3 @@
+# QCSC Prefect Qiskit
+
+Native Qiskit Runtime integration utilities for QCSC Prefect workflows.

--- a/packages/qcsc-prefect-qiskit/pyproject.toml
+++ b/packages/qcsc-prefect-qiskit/pyproject.toml
@@ -1,16 +1,32 @@
 [build-system]
-requires = ["setuptools>=68", "wheel"]
+requires = ["setuptools>=77.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "qcsc-prefect-qiskit"
 version = "0.1.0"
 description = "Native Qiskit integration utilities for QCSC Prefect workflows"
+readme = "README.md"
 requires-python = ">=3.10"
+license = "Apache-2.0"
+authors = [
+    { name = "QCSC Prefect Contributors" },
+]
+maintainers = [
+    { name = "QCSC Prefect Maintainers" },
+]
 dependencies = [
+    "anyio>=4",
     "prefect>=2.19",
+    "pydantic>=2",
     "qiskit-ibm-runtime>=0.46",
 ]
+
+[project.urls]
+Homepage = "https://github.com/qiskit-community/qcsc-prefect"
+Repository = "https://github.com/qiskit-community/qcsc-prefect"
+Documentation = "https://qiskit-community.github.io/qcsc-prefect/"
+Issues = "https://github.com/qiskit-community/qcsc-prefect/issues"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/packages/qcsc-prefect/README.md
+++ b/packages/qcsc-prefect/README.md
@@ -1,0 +1,9 @@
+# QCSC Prefect
+
+Meta-package that installs the core QCSC Prefect packages.
+
+Optional extras:
+
+- `qcsc-prefect[qiskit]` installs the native Qiskit Runtime integration.
+- `qcsc-prefect[dice]` installs the Python-side DICE integration.
+- `qcsc-prefect[all]` installs all optional QCSC Prefect integrations.

--- a/packages/qcsc-prefect/pyproject.toml
+++ b/packages/qcsc-prefect/pyproject.toml
@@ -3,9 +3,9 @@ requires = ["setuptools>=77.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "qcsc-prefect-core"
+name = "qcsc-prefect"
 version = "0.1.0"
-description = "Core models and resolution logic for QCSC Prefect workflows"
+description = "Meta-package for installing QCSC Prefect core packages"
 readme = "README.md"
 requires-python = ">=3.10"
 license = "Apache-2.0"
@@ -15,7 +15,24 @@ authors = [
 maintainers = [
     { name = "QCSC Prefect Maintainers" },
 ]
-dependencies = []
+dependencies = [
+    "qcsc-prefect-adapters==0.1.0",
+    "qcsc-prefect-blocks==0.1.0",
+    "qcsc-prefect-core==0.1.0",
+    "qcsc-prefect-executor==0.1.0",
+]
+
+[project.optional-dependencies]
+qiskit = [
+    "qcsc-prefect-qiskit==0.1.0",
+]
+dice = [
+    "qcsc-prefect-dice==0.1.0",
+]
+all = [
+    "qcsc-prefect-dice==0.1.0",
+    "qcsc-prefect-qiskit==0.1.0",
+]
 
 [project.urls]
 Homepage = "https://github.com/qiskit-community/qcsc-prefect"
@@ -23,5 +40,5 @@ Repository = "https://github.com/qiskit-community/qcsc-prefect"
 Documentation = "https://qiskit-community.github.io/qcsc-prefect/"
 Issues = "https://github.com/qiskit-community/qcsc-prefect/issues"
 
-[tool.setuptools.packages.find]
-where = ["src"]
+[tool.setuptools]
+packages = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ packages = []
 # --- uv ---
 [tool.uv.workspace]
 members = [
+    "packages/qcsc-prefect",
     "packages/qcsc-prefect-core",
     "packages/qcsc-prefect-adapters",
     "packages/qcsc-prefect-blocks",
@@ -34,6 +35,7 @@ members = [
 
 
 [tool.uv.sources]
+qcsc-prefect          = { workspace = true }
 qcsc-prefect-core     = { workspace = true }
 qcsc-prefect-adapters = { workspace = true }
 qcsc-prefect-blocks   = { workspace = true }
@@ -54,6 +56,7 @@ python = ">=3.10"
 
 [tool.poetry.workspace]
 members = [
+    "packages/qcsc-prefect",
     "packages/qcsc-prefect-core",
     "packages/qcsc-prefect-adapters",
     "packages/qcsc-prefect-blocks",
@@ -65,6 +68,7 @@ members = [
 # --- Hatch ---
 [tool.hatch.workspace]
 members = [
+    "packages/qcsc-prefect",
     "packages/qcsc-prefect-core",
     "packages/qcsc-prefect-adapters",
     "packages/qcsc-prefect-blocks",

--- a/scripts/build-all-packages.sh
+++ b/scripts/build-all-packages.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DIST_DIR="${ROOT_DIR}/dist"
+PYTHON_BIN="${PYTHON:-}"
+
+if [[ -z "${PYTHON_BIN}" ]]; then
+  if command -v python >/dev/null 2>&1; then
+    PYTHON_BIN="python"
+  elif command -v python3 >/dev/null 2>&1; then
+    PYTHON_BIN="python3"
+  else
+    echo "Could not find python or python3 on PATH." >&2
+    exit 1
+  fi
+fi
+
+packages=(
+  "packages/qcsc-prefect-core"
+  "packages/qcsc-prefect-blocks"
+  "packages/qcsc-prefect-adapters"
+  "packages/qcsc-prefect-executor"
+  "packages/qcsc-prefect-qiskit"
+  "packages/qcsc-prefect-dice"
+  "packages/qcsc-prefect"
+)
+
+rm -rf "${DIST_DIR}"
+mkdir -p "${DIST_DIR}"
+
+for package in "${packages[@]}"; do
+  "${PYTHON_BIN}" -m build --outdir "${DIST_DIR}" "${ROOT_DIR}/${package}"
+done
+
+"${PYTHON_BIN}" -m twine check "${DIST_DIR}"/*


### PR DESCRIPTION
Production release notes for maintainers:

1. Create GitHub Environments in qiskit-community/qcsc-prefect:
   - testpypi
   - pypi

2. Configure PyPI Trusted Publishers using:
   Owner: qiskit-community
   Repository: qcsc-prefect
   Workflow filename: pypi-publish.yml
   Environment name: pypi

3. For the initial PyPI project creation, note that pending publishers may not support bootstrapping multiple projects with the same owner/repo/workflow/environment identity.

   If this happens, bootstrap the PyPI projects once using maintainer-controlled PyPI credentials, then add Trusted Publisher to each existing project.

4. After Trusted Publisher is configured for all projects, publish by pushing a version tag:
      git tag v0.1.0
      git push origin v0.1.0